### PR TITLE
Ss wallet alert logo update

### DIFF
--- a/srcs/app/frontend/package-lock.json
+++ b/srcs/app/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@coral-xyz/anchor": "^0.30.1",
         "@project-serum/anchor": "^0.26.0",
+        "@solana/wallet-adapter-backpack": "^0.1.14",
         "@solana/wallet-adapter-base": "^0.9.23",
         "@solana/wallet-adapter-brave": "^0.1.17",
         "@solana/wallet-adapter-react": "^0.15.35",
@@ -5441,6 +5442,22 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-avana/-/wallet-adapter-avana-0.1.13.tgz",
       "integrity": "sha512-dvKDzaFo9KgfNh0ohI6qOBTnOU2f6cHKPiDxdtLfXVubdic1mUYzuA2PcrBZQuRc5EBcvHbGCpr3Ds90cGB+xQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/wallet-adapter-base": "^0.9.23"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.77.3"
+      }
+    },
+    "node_modules/@solana/wallet-adapter-backpack": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-backpack/-/wallet-adapter-backpack-0.1.14.tgz",
+      "integrity": "sha512-DfNLd5S1P7rmrgqMp+jRd21ryuXUxia1mu4qmZ+cau1NGFO2v5ep14LhzYXmqPde6kgbzPLPkLdRnkffLdI4TA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"

--- a/srcs/app/frontend/package.json
+++ b/srcs/app/frontend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1",
     "@project-serum/anchor": "^0.26.0",
+    "@solana/wallet-adapter-backpack": "^0.1.14",
     "@solana/wallet-adapter-base": "^0.9.23",
     "@solana/wallet-adapter-brave": "^0.1.17",
     "@solana/wallet-adapter-react": "^0.15.35",

--- a/srcs/app/frontend/src/app/Providers/WalletProvider.tsx
+++ b/srcs/app/frontend/src/app/Providers/WalletProvider.tsx
@@ -8,8 +8,12 @@ import {
 import {
   PhantomWalletAdapter,
   SolflareWalletAdapter,
+  TrustWalletAdapter,
+  LedgerWalletAdapter,
+  CoinbaseWalletAdapter,
 } from '@solana/wallet-adapter-wallets';
 import { BraveWalletAdapter } from '@solana/wallet-adapter-brave'; // 追加
+import { BackpackWalletAdapter } from '@solana/wallet-adapter-backpack'; // 追加
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
 import '@solana/wallet-adapter-react-ui/styles.css';
 import '../styles/Providers/Wallet-adapter-override.css'; // 新しく追加
@@ -31,6 +35,10 @@ export default function WalletProviderWrapper({
       new PhantomWalletAdapter(),
       new SolflareWalletAdapter(),
       new BraveWalletAdapter(), // 追加
+      new TrustWalletAdapter(),
+      new LedgerWalletAdapter(),
+      new CoinbaseWalletAdapter(),
+      new BackpackWalletAdapter(), // 追加
     ],
     [connection]
   );

--- a/srcs/app/frontend/src/app/components/Home/Body/Buyer/ReturnSolButton.tsx
+++ b/srcs/app/frontend/src/app/components/Home/Body/Buyer/ReturnSolButton.tsx
@@ -31,11 +31,10 @@ const ReturnSolButton: React.FC<ReturnSolButtonProps> = ({
         seller_pubkey,
         Number(transactionId)
       );
-      alert(`${f}`);
+      alert(`Success`);
     } else {
-      alert(`wallet 接続されていない`);
+      alert(`Error: No wallet connected`);
     }
-    alert(`Hello! ${buyer_pubkey}`);
   };
   return (
     <button className={styles.ButtonContainer} onClick={onClick}>

--- a/srcs/app/frontend/src/app/components/Home/Body/Buyer/ReturnSolButton.tsx
+++ b/srcs/app/frontend/src/app/components/Home/Body/Buyer/ReturnSolButton.tsx
@@ -31,7 +31,11 @@ const ReturnSolButton: React.FC<ReturnSolButtonProps> = ({
         seller_pubkey,
         Number(transactionId)
       );
-      alert(`Success`);
+      if (f) {
+        alert(`Success`);
+      } else {
+        alert(`Failure`);
+      }
     } else {
       alert(`Error: No wallet connected`);
     }

--- a/srcs/app/frontend/src/app/components/Home/Body/Seller/WithdrawButton.tsx
+++ b/srcs/app/frontend/src/app/components/Home/Body/Seller/WithdrawButton.tsx
@@ -31,11 +31,10 @@ const WithdrawButton: React.FC<WithdrawButtonProps> = ({
         seller_pubkey,
         Number(transactionId)
       );
-      alert(`${f}`);
+      alert(`Success`);
     } else {
-      alert(`wallet 接続されていない`);
+      alert(`Error: No wallet connected`);
     }
-    alert('Hello, world!');
   };
   return (
     <button className={styles.ButtonContainer} onClick={onClick}>

--- a/srcs/app/frontend/src/app/components/Home/Body/Seller/WithdrawButton.tsx
+++ b/srcs/app/frontend/src/app/components/Home/Body/Seller/WithdrawButton.tsx
@@ -31,7 +31,11 @@ const WithdrawButton: React.FC<WithdrawButtonProps> = ({
         seller_pubkey,
         Number(transactionId)
       );
-      alert(`Success`);
+      if (f) {
+        alert(`Success`);
+      } else {
+        alert(`Failure`);
+      }
     } else {
       alert(`Error: No wallet connected`);
     }

--- a/srcs/app/frontend/src/app/components/Home/Header/JinLogo.tsx
+++ b/srcs/app/frontend/src/app/components/Home/Header/JinLogo.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Link from 'next/link';
 import styles from '../../../styles/Header/JinLogo.module.css';
 
 const JinLogo: React.FC = () => {

--- a/srcs/app/frontend/src/app/components/Home/Header/JinLogo.tsx
+++ b/srcs/app/frontend/src/app/components/Home/Header/JinLogo.tsx
@@ -4,9 +4,7 @@ import styles from '../../../styles/Header/JinLogo.module.css';
 
 const JinLogo: React.FC = () => {
   return (
-    <Link href="/" className={styles.logo}>
-      Jin
-    </Link>
+    <div className={styles.logo}>Jin</div>
   );
 };
 

--- a/srcs/app/frontend/src/app/components/Home/Header/JinLogo.tsx
+++ b/srcs/app/frontend/src/app/components/Home/Header/JinLogo.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import styles from '../../../styles/Header/JinLogo.module.css';
 
 const JinLogo: React.FC = () => {
-  return (
-    <div className={styles.logo}>Jin</div>
-  );
+  return <div className={styles.logo}>Jin</div>;
 };
 
 export default JinLogo;

--- a/srcs/app/frontend/src/app/components/api.ts
+++ b/srcs/app/frontend/src/app/components/api.ts
@@ -67,7 +67,7 @@ export async function addNewTransaction(
     await CONNECTION.confirmTransaction(signature, 'processed');
     return true;
   } catch (e) {
-    alert(`ERROR: ${e}`);
+    alert(`Error: ${e}`);
     return false;
   }
 }

--- a/srcs/app/frontend/src/app/styles/Body/Buyer/ReturnSolButton.module.css
+++ b/srcs/app/frontend/src/app/styles/Body/Buyer/ReturnSolButton.module.css
@@ -8,4 +8,5 @@
   background-color: #ffdbc9;
   font-size: 2rem;
   cursor: pointer;
+  color: #000000;
 }

--- a/srcs/app/frontend/src/app/styles/Body/Seller/WithdrawButton.module.css
+++ b/srcs/app/frontend/src/app/styles/Body/Seller/WithdrawButton.module.css
@@ -8,4 +8,5 @@
   background-color: #ffdbc9;
   font-size: 2rem;
   cursor: pointer;
+  color: #000000;
 }


### PR DESCRIPTION
1. ボタンの文字色修正
   - 「return」と「withdraw」ボタンの文字色が環境によって白くなる問題を修正。
   - CSSを変更し、文字色を明示的に黒に指定。

2. フォームの自動補完による色変更
   - 「add new transaction」で補完機能使用時に色が変わる問題は対応不要と判断。
   - これはブラウザの「オートフィル」または「オートコンプリート」機能によるもの。
   - ユーザーの利便性向上のため、ブラウザが提供する機能であり、ブラウザ側で制御可能。

3. デバッグ用アラートの削除
   - 不要なalertを削除。
   - 必要なalertのメッセージを適宜修正。

4. ロゴのリンク機能削除
   - ロゴをクリックしてルートページに遷移する機能を削除。
   - `<Link>` の代わりに `<div>` を使用して、遷移を無効化。

5. ウォレット対応の改善
   - 接続可能なウォレットはSolanaのウォレットライブラリで自動対応。
   - 明示的に指定していないウォレットでも接続・取引が可能であることを確認。
   - 追加のウォレット制限は不要と判断し、新しいウォレットの追加のみ実施。